### PR TITLE
Remove CryptoKit cocoapod in favour of Apple's CryptoKit

### DIFF
--- a/firebase_auth_oauth/CHANGELOG.md
+++ b/firebase_auth_oauth/CHANGELOG.md
@@ -1,10 +1,18 @@
+## 0.2.3
+
+* Replace CryptoKit pod with Apple's CryptoKit framework
+
 ## 0.2.2
-* Fixed crash on iOS when using Microsoft sign in. Thanks to [@camillobucciarelli](https://github.com/camillobucciarelli).
+
+* Fixed crash on iOS when using Microsoft sign in. Thanks
+  to [@camillobucciarelli](https://github.com/camillobucciarelli).
 
 ## 0.2.1
+
 * Fixed Firebase not initialised issue when using this plugin
 
 ## 0.2.0
+
 * Migrated to `firebase_auth` ^0.18.0+1
 * Migrated to `firebase_auth` ^0.5.0
 * Added `linkExistingUserWithCredentials` to link existing user with OAuth credentials

--- a/firebase_auth_oauth/example/ios/Podfile.lock
+++ b/firebase_auth_oauth/example/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - CryptoKit (0.4.0)
+  - CryptoSwift (1.2.0)
   - Firebase/Auth (6.26.0):
     - Firebase/CoreOnly
     - FirebaseAuth (~> 6.5.3)
@@ -11,7 +11,7 @@ PODS:
     - firebase_core
     - Flutter
   - firebase_auth_oauth (0.0.1):
-    - CryptoKit (~> 0.4)
+    - CryptoSwift (~> 1.2.0)
     - firebase_auth
     - Flutter
   - firebase_core (0.5.0):
@@ -69,7 +69,7 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - CryptoKit
+    - CryptoSwift
     - Firebase
     - FirebaseAuth
     - FirebaseAuthInterop
@@ -93,10 +93,10 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  CryptoKit: 778b0eb14434535f70fd1037b297841dd83e3c37
+  CryptoSwift: 40e374e45291d8dceedcb0d6184da94533eaabdf
   Firebase: 7cf5f9c67f03cb3b606d1d6535286e1080e57eb6
   firebase_auth: c42c06a212439824b5da53437da905931e8e6b9a
-  firebase_auth_oauth: e8041e29e7004b8656784c64b367e94ea97c1010
+  firebase_auth_oauth: 121b300c755c06aad095732237bafd272dc769d4
   firebase_core: 3134fe79d257d430f163b558caf52a10a87efe8a
   FirebaseAuth: 7047aec89c0b17ecd924a550c853f0c27ac6015e
   FirebaseAuthInterop: a0f37ae05833af156e72028f648d313f7e7592e9

--- a/firebase_auth_oauth/example/ios/Podfile.lock
+++ b/firebase_auth_oauth/example/ios/Podfile.lock
@@ -1,5 +1,4 @@
 PODS:
-  - CryptoSwift (1.2.0)
   - Firebase/Auth (6.26.0):
     - Firebase/CoreOnly
     - FirebaseAuth (~> 6.5.3)
@@ -11,7 +10,6 @@ PODS:
     - firebase_core
     - Flutter
   - firebase_auth_oauth (0.0.1):
-    - CryptoSwift (~> 1.2.0)
     - firebase_auth
     - Flutter
   - firebase_core (0.5.0):
@@ -69,7 +67,6 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - CryptoSwift
     - Firebase
     - FirebaseAuth
     - FirebaseAuthInterop
@@ -93,10 +90,9 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  CryptoSwift: 40e374e45291d8dceedcb0d6184da94533eaabdf
   Firebase: 7cf5f9c67f03cb3b606d1d6535286e1080e57eb6
   firebase_auth: c42c06a212439824b5da53437da905931e8e6b9a
-  firebase_auth_oauth: 121b300c755c06aad095732237bafd272dc769d4
+  firebase_auth_oauth: db7ad66aa729b98ed87ce68cfaa6bbf96cd65c74
   firebase_core: 3134fe79d257d430f163b558caf52a10a87efe8a
   FirebaseAuth: 7047aec89c0b17ecd924a550c853f0c27ac6015e
   FirebaseAuthInterop: a0f37ae05833af156e72028f648d313f7e7592e9

--- a/firebase_auth_oauth/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/firebase_auth_oauth/example/ios/Runner.xcodeproj/project.pbxproj
@@ -219,7 +219,6 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/CryptoSwift/CryptoSwift.framework",
 				"${PODS_ROOT}/../Flutter/Flutter.framework",
 				"${BUILT_PRODUCTS_DIR}/GTMSessionFetcher/GTMSessionFetcher.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleUtilities/GoogleUtilities.framework",
@@ -228,7 +227,6 @@
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CryptoSwift.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMSessionFetcher.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleUtilities.framework",

--- a/firebase_auth_oauth/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/firebase_auth_oauth/example/ios/Runner.xcodeproj/project.pbxproj
@@ -219,7 +219,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/CryptoKit/CryptoKit.framework",
+				"${BUILT_PRODUCTS_DIR}/CryptoSwift/CryptoSwift.framework",
 				"${PODS_ROOT}/../Flutter/Flutter.framework",
 				"${BUILT_PRODUCTS_DIR}/GTMSessionFetcher/GTMSessionFetcher.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleUtilities/GoogleUtilities.framework",
@@ -228,7 +228,7 @@
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CryptoKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CryptoSwift.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMSessionFetcher.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleUtilities.framework",

--- a/firebase_auth_oauth/example/pubspec.lock
+++ b/firebase_auth_oauth/example/pubspec.lock
@@ -77,21 +77,21 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.0"
+    version: "0.2.2"
   firebase_auth_oauth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_oauth_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.1"
   firebase_auth_oauth_web:
     dependency: transitive
     description:
-      path: "../../firebase_auth_oauth_web"
-      relative: true
-    source: path
-    version: "0.2.0"
+      name: firebase_auth_oauth_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.1"
   firebase_auth_platform_interface:
     dependency: transitive
     description:

--- a/firebase_auth_oauth/example/pubspec.lock
+++ b/firebase_auth_oauth/example/pubspec.lock
@@ -77,7 +77,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.2"
+    version: "0.2.3"
   firebase_auth_oauth_platform_interface:
     dependency: transitive
     description:

--- a/firebase_auth_oauth/ios/Classes/FirebaseAuthOAuthPlugin+AppleSignIniOS13.swift
+++ b/firebase_auth_oauth/ios/Classes/FirebaseAuthOAuthPlugin+AppleSignIniOS13.swift
@@ -6,7 +6,7 @@
 //
 
 import AuthenticationServices
-import CryptoSwift
+import CryptoKit
 import FirebaseAuth
 
 
@@ -55,11 +55,9 @@ extension FirebaseAuthOAuthViewController: ASAuthorizationControllerDelegate {
 	
 	@available(iOS 13, *)
 	private func sha256(_ input: String) -> String {
-		let inputData = Data(input.utf8)
-		return inputData.sha256().compactMap {
+		return SHA256.hash(data: Data(input.utf8)).compactMap {
 			return String(format: "%02x", $0)
 		}.joined()
-		
 	}
 	
 	// Adapted from https://auth0.com/docs/api-auth/tutorials/nonce#generate-a-cryptographically-random-nonce

--- a/firebase_auth_oauth/ios/Classes/FirebaseAuthOAuthPlugin+AppleSignIniOS13.swift
+++ b/firebase_auth_oauth/ios/Classes/FirebaseAuthOAuthPlugin+AppleSignIniOS13.swift
@@ -6,7 +6,7 @@
 //
 
 import AuthenticationServices
-import CryptoKit
+import CryptoSwift
 import FirebaseAuth
 
 
@@ -56,7 +56,7 @@ extension FirebaseAuthOAuthViewController: ASAuthorizationControllerDelegate {
 	@available(iOS 13, *)
 	private func sha256(_ input: String) -> String {
 		let inputData = Data(input.utf8)
-		return inputData.digest(using: .sha256).compactMap {
+		return inputData.sha256().compactMap {
 			return String(format: "%02x", $0)
 		}.joined()
 		

--- a/firebase_auth_oauth/ios/firebase_auth_oauth.podspec
+++ b/firebase_auth_oauth/ios/firebase_auth_oauth.podspec
@@ -16,8 +16,9 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.dependency 'firebase_auth'
-  s.dependency 'CryptoSwift', '~> 1.2.0'
+#   s.dependency 'CryptoSwift', '~> 1.2.0'
   s.framework = 'AuthenticationServices'
+  s.framework = 'CryptoKit'
   s.static_framework = true
   s.platform = :ios, '9.0'
 

--- a/firebase_auth_oauth/ios/firebase_auth_oauth.podspec
+++ b/firebase_auth_oauth/ios/firebase_auth_oauth.podspec
@@ -16,7 +16,7 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.dependency 'firebase_auth'
-  s.dependency 'CryptoKit', '~> 0.4'
+  s.dependency 'CryptoSwift', '~> 1.2.0'
   s.framework = 'AuthenticationServices'
   s.static_framework = true
   s.platform = :ios, '9.0'

--- a/firebase_auth_oauth/pubspec.lock
+++ b/firebase_auth_oauth/pubspec.lock
@@ -70,14 +70,14 @@ packages:
       name: firebase_auth_oauth_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.1"
   firebase_auth_oauth_web:
     dependency: "direct main"
     description:
-      path: "../firebase_auth_oauth_web"
-      relative: true
-    source: path
-    version: "0.2.0"
+      name: firebase_auth_oauth_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.1"
   firebase_auth_platform_interface:
     dependency: transitive
     description:

--- a/firebase_auth_oauth/pubspec.yaml
+++ b/firebase_auth_oauth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_auth_oauth
 description: A Flutter plugin that makes it easy to perform OAuth sign in flows using FirebaseAuth. It also includes support for Sign in by Apple for Firebase.
-version: 0.2.2
+version: 0.2.3
 author: Amr Yousef <contact@amryousef.me>
 homepage: https://github.com/amrfarid140/firebase_auth_oauth/tree/master/firebase_auth_oauth
 

--- a/firebase_auth_oauth_web/pubspec.lock
+++ b/firebase_auth_oauth_web/pubspec.lock
@@ -70,7 +70,7 @@ packages:
       name: firebase_auth_oauth_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.1"
   firebase_auth_platform_interface:
     dependency: transitive
     description:


### PR DESCRIPTION
**Description**
Thanks to #33 I had another look into CryptoKit pod usage and it's only used in the Apple Sign In flow which already requires iOS 13. This means that we can use Apple's own CryptoKit. 