### PR TITLE
CHANGELOG.md: Removed empty lines after verion headlines

### DIFF
--- a/firebase_auth_oauth/CHANGELOG.md
+++ b/firebase_auth_oauth/CHANGELOG.md
@@ -3,20 +3,16 @@
 * Updated `firebase_core` to Version ^0.7.0
 
 ## 0.2.3
-
 * Replace CryptoKit pod with Apple's CryptoKit framework
 
 ## 0.2.2
-
 * Fixed crash on iOS when using Microsoft sign in. Thanks
   to [@camillobucciarelli](https://github.com/camillobucciarelli).
 
 ## 0.2.1
-
 * Fixed Firebase not initialised issue when using this plugin
 
 ## 0.2.0
-
 * Migrated to `firebase_auth` ^0.18.0+1
 * Migrated to `firebase_auth` ^0.5.0
 * Added `linkExistingUserWithCredentials` to link existing user with OAuth credentials


### PR DESCRIPTION
Just a small PR: When I created https://github.com/amrfarid140/firebase_auth_oauth/pull/36 I was confused if I should add an empty line after a version headline (both versions were be used in `firebaes_auth_oauth/CHANLOG.md`. We should keep to one format, so I removed the empty lines after a version headline.