### PR TITLE
Update dependencies to null safety

### DIFF
--- a/firebase_auth_oauth/pubspec.lock
+++ b/firebase_auth_oauth/pubspec.lock
@@ -7,76 +7,76 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   firebase:
     dependency: transitive
     description:
       name: firebase
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.3.0"
+    version: "9.0.0"
   firebase_auth:
     dependency: "direct main"
     description:
       name: firebase_auth
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.20.0+1"
+    version: "1.0.0"
   firebase_auth_oauth_platform_interface:
     dependency: "direct main"
     description:
-      name: firebase_auth_oauth_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../firebase_auth_oauth_platform_interface"
+      relative: true
+    source: path
     version: "0.2.2"
   firebase_auth_oauth_web:
     dependency: "direct main"
     description:
-      name: firebase_auth_oauth_web
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../firebase_auth_oauth_web"
+      relative: true
+    source: path
     version: "0.2.2"
   firebase_auth_platform_interface:
     dependency: transitive
@@ -84,35 +84,35 @@ packages:
       name: firebase_auth_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "4.0.0"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.2+6"
+    version: "1.0.0"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.0"
+    version: "1.0.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "4.0.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1+3"
+    version: "1.0.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -134,70 +134,63 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.0+4"
+    version: "0.13.0"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.3"
+    version: "4.0.0"
   intl:
     dependency: transitive
     description:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.16.1"
+    version: "0.17.0"
   js:
     dependency: transitive
     description:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3-nullsafety.1"
+    version: "0.6.3"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.4"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0+1"
+    version: "1.10.0"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.3"
+    version: "2.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -209,56 +202,56 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.2"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.10.0-110 <=2.11.0-213.1.beta"
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  dart: ">=2.12.0-0.0 <3.0.0"
+  flutter: ">=1.12.13+hotfix.5"

--- a/firebase_auth_oauth/pubspec.yaml
+++ b/firebase_auth_oauth/pubspec.yaml
@@ -12,10 +12,8 @@ dependencies:
   flutter:
     sdk: flutter
   firebase_auth: ^1.0.0
-  firebase_auth_oauth_platform_interface:
-    path: ../firebase_auth_oauth_platform_interface
-  firebase_auth_oauth_web:
-    path: ../firebase_auth_oauth_web
+  firebase_auth_oauth_platform_interface: ^1.0.0
+  firebase_auth_oauth_web: ^1.0.0
   firebase_core: ^1.0.0
 
 dev_dependencies:

--- a/firebase_auth_oauth/pubspec.yaml
+++ b/firebase_auth_oauth/pubspec.yaml
@@ -1,8 +1,7 @@
 name: firebase_auth_oauth
 description: A Flutter plugin that makes it easy to perform OAuth sign in flows using FirebaseAuth. It also includes support for Sign in by Apple for Firebase.
-version: 0.2.4
+version: 1.0.0
 homepage: https://github.com/amrfarid140/firebase_auth_oauth/tree/master/firebase_auth_oauth
-publish_to: none
 
 environment:
   sdk: ">=2.2.2 <3.0.0"

--- a/firebase_auth_oauth/pubspec.yaml
+++ b/firebase_auth_oauth/pubspec.yaml
@@ -2,6 +2,7 @@ name: firebase_auth_oauth
 description: A Flutter plugin that makes it easy to perform OAuth sign in flows using FirebaseAuth. It also includes support for Sign in by Apple for Firebase.
 version: 0.2.4
 homepage: https://github.com/amrfarid140/firebase_auth_oauth/tree/master/firebase_auth_oauth
+publish_to: none
 
 environment:
   sdk: ">=2.2.2 <3.0.0"
@@ -10,10 +11,12 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  firebase_auth: ^0.20.0+1
-  firebase_auth_oauth_platform_interface: ^0.2.2
-  firebase_auth_oauth_web: ^0.2.2
-  firebase_core: ^0.7.0
+  firebase_auth: ^1.0.0
+  firebase_auth_oauth_platform_interface:
+    path: ../firebase_auth_oauth_platform_interface
+  firebase_auth_oauth_web:
+    path: ../firebase_auth_oauth_web
+  firebase_core: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/firebase_auth_oauth_platform_interface/pubspec.lock
+++ b/firebase_auth_oauth_platform_interface/pubspec.lock
@@ -7,91 +7,91 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   firebase_auth:
     dependency: "direct main"
     description:
       name: firebase_auth
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.20.0+1"
+    version: "1.0.0"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "4.0.0"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.2+6"
+    version: "1.0.0"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.0"
+    version: "1.0.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "4.0.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1+3"
+    version: "1.0.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -113,42 +113,42 @@ packages:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.3"
+    version: "4.0.0"
   intl:
     dependency: transitive
     description:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.16.1"
+    version: "0.17.0"
   js:
     dependency: transitive
     description:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3-nullsafety.1"
+    version: "0.6.3"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.4"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0"
   pedantic:
     dependency: "direct dev"
     description:
@@ -162,14 +162,7 @@ packages:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.3"
+    version: "2.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -181,56 +174,56 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.2"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.10.0-110 <=2.11.0-213.1.beta"
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  dart: ">=2.12.0-0.0 <3.0.0"
+  flutter: ">=1.12.13+hotfix.5"

--- a/firebase_auth_oauth_platform_interface/pubspec.yaml
+++ b/firebase_auth_oauth_platform_interface/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  firebase_auth: ^0.20.0+1
-  firebase_core: ^0.7.0
+  firebase_auth: ^1.0.0
+  firebase_core: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/firebase_auth_oauth_platform_interface/pubspec.yaml
+++ b/firebase_auth_oauth_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_auth_oauth_platform_interface
 description: Platform interface plugin for firebase_auth_oauth. This includes
   API definition which will be implemented for android, ios and web.
-version: 0.2.2
+version: 1.0.0
 homepage: https://github.com/amrfarid140/firebase_auth_oauth/tree/master/firebase_auth_oauth_platform_interface
 
 environment:

--- a/firebase_auth_oauth_web/pubspec.yaml
+++ b/firebase_auth_oauth_web/pubspec.yaml
@@ -1,8 +1,7 @@
 name: firebase_auth_oauth_web
 description: Web implementation for `firebase_auth_oauth`.  Don't use directly. Instead import `firebase_auth_oauth` plugin.
-version: 0.2.2
+version: 1.0.0
 homepage: https://github.com/amrfarid140/firebase_auth_oauth/tree/master/firebase_auth_oauth_web
-publish_to: none
 
 environment:
   sdk: ">=2.2.2 <3.0.0"

--- a/firebase_auth_oauth_web/pubspec.yaml
+++ b/firebase_auth_oauth_web/pubspec.yaml
@@ -2,6 +2,7 @@ name: firebase_auth_oauth_web
 description: Web implementation for `firebase_auth_oauth`.  Don't use directly. Instead import `firebase_auth_oauth` plugin.
 version: 0.2.2
 homepage: https://github.com/amrfarid140/firebase_auth_oauth/tree/master/firebase_auth_oauth_web
+publish_to: none
 
 environment:
   sdk: ">=2.2.2 <3.0.0"
@@ -12,10 +13,11 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  firebase: ^7.3.0
-  firebase_auth: ^0.20.0+1
-  firebase_auth_oauth_platform_interface: ^0.2.2
-  firebase_core: ^0.7.0
+  firebase: ^9.0.0
+  firebase_auth: ^1.0.0
+  firebase_auth_oauth_platform_interface:
+    path: ../firebase_auth_oauth_platform_interface
+  firebase_core: ^1.0.0
   js: ^0.6.2
 
 dev_dependencies:

--- a/firebase_auth_oauth_web/pubspec.yaml
+++ b/firebase_auth_oauth_web/pubspec.yaml
@@ -15,8 +15,7 @@ dependencies:
     sdk: flutter
   firebase: ^9.0.0
   firebase_auth: ^1.0.0
-  firebase_auth_oauth_platform_interface:
-    path: ../firebase_auth_oauth_platform_interface
+  firebase_auth_oauth_platform_interface: ^1.0.0
   firebase_core: ^1.0.0
   js: ^0.6.2
 


### PR DESCRIPTION
This fixes dependency resolving issues and upgrades dependencies to the null safety versions.

re #38 

Note: I wasn't sure how to deal with referencing packages that don't exist yet (ie: firebase_auth_oauth referencing firebase_auth_oauth_platform_interface and firebase_auth_oauth_web that aren't pushed to pub.dev) so this won't work until those two sub packages get pushed first I assume. This also assume a new 1.0.0 release for these packages. 
