### PR TITLE
switch example to dart initialization

### DIFF
--- a/firebase_auth_oauth/example/lib/main.dart
+++ b/firebase_auth_oauth/example/lib/main.dart
@@ -8,7 +8,17 @@ import 'package:flutter/services.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp();
+  await Firebase.initializeApp(
+    options: FirebaseOptions(
+      apiKey: "AIzaSyDiSdrRegqkVpOAeC9qgjj43e_1jO9PIN0",
+      authDomain: "testfirestore-fd7e2.firebaseapp.com",
+      databaseURL: "https://testfirestore-fd7e2.firebaseio.com",
+      projectId: "testfirestore-fd7e2",
+      storageBucket: "testfirestore-fd7e2.appspot.com",
+      messagingSenderId: "719377316001",
+      appId: "1:719377316001:web:a9d3a2db8fceaa2e21d8e0",
+    ),
+  );
   runApp(MyApp());
 }
 

--- a/firebase_auth_oauth/example/web/index.html
+++ b/firebase_auth_oauth/example/web/index.html
@@ -3,22 +3,6 @@
 <head>
   <meta charset="UTF-8">
   <title>firebase_apple_auth_example</title>
-  <!-- The core Firebase JS SDK is always required and must be listed first -->
-  <script src="https://www.gstatic.com/firebasejs/7.6.1/firebase-app.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/7.6.1/firebase-auth.js"></script>
-
-  <script>
-  var firebaseConfig = {
-    apiKey: "AIzaSyDiSdrRegqkVpOAeC9qgjj43e_1jO9PIN0",
-    authDomain: "testfirestore-fd7e2.firebaseapp.com",
-    databaseURL: "https://testfirestore-fd7e2.firebaseio.com",
-    projectId: "testfirestore-fd7e2",
-    storageBucket: "testfirestore-fd7e2.appspot.com",
-    messagingSenderId: "719377316001",
-    appId: "1:719377316001:web:a9d3a2db8fceaa2e21d8e0"
-  };
-  firebase.initializeApp(firebaseConfig);
-</script>
 </head>
 <body>
   <script src="main.dart.js" type="application/javascript"></script>


### PR DESCRIPTION
For me, the example did not work with flutter 3.0.4.
When I changed to dart-only-initialization, it worked again.
I did not find any official doc which confirms that this is necessary.